### PR TITLE
remove reference to .net 1.0.4

### DIFF
--- a/src/TechJobsConsole/TechJobsConsole.csproj
+++ b/src/TechJobsConsole/TechJobsConsole.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>TechJobsConsole</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>TechJobsConsole</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>


### PR DESCRIPTION
- Fixes error related to .csproj referencing a version of .net that some students may not have.
- Code change needed because changing the .net version in the UI did not fix the issue.

Example or error:
![screen shot 2017-11-05 at 5 10 41 pm](https://user-images.githubusercontent.com/474646/32420226-7baf2cf6-c24c-11e7-960c-430a3c2c1653.png)
